### PR TITLE
Parse scripts from YAML configuration file.

### DIFF
--- a/bin/appveyor-runner
+++ b/bin/appveyor-runner
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 require('babel-polyfill');
-require('../dist/cli').default();
+require('../dist/cli').default(process.argv[2]);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-polyfill": "^6.9.1",
     "concat-stream": "^1.5.1",
     "download": "^5.0.2",
+    "js-yaml": "^3.6.1",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^2.0.0",
     "semver": "^5.3.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,10 @@ export default async function cli(configFile) {
   const configDir = path.dirname(configFile);
   const config = await parseConfig(configFile);
 
+  const cwd = config.cwd
+    ? path.resolve(configDir, config.cwd)
+    : process.cwd();
+
   const binDir = config.bin
     ? path.resolve(configDir, config.bin)
     : path.resolve(process.cwd(), 'node_bin');
@@ -17,7 +21,7 @@ export default async function cli(configFile) {
   return runner(
     process.stdout,
     process.stderr,
-    process.cwd(),
+    cwd,
     binDir,
     logDir,
     config.versions,

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,8 +2,8 @@ import path from 'path';
 import runner from './index';
 import parseConfig from './parse-config';
 
-export default async function cli(configFile) {
-  const configDir = path.dirname(configFile);
+export default async function cli(configFile = 'appveyor.yml') {
+  const configDir = path.dirname(path.resolve(process.cwd(), configFile));
   const config = await parseConfig(configFile);
 
   const cwd = config.cwd
@@ -24,7 +24,7 @@ export default async function cli(configFile) {
     cwd,
     binDir,
     logDir,
-    config.versions,
-    config.scripts,
+    config.versions || [],
+    config.scripts || [],
   );
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,14 +1,16 @@
 import path from 'path';
 import runner from './index';
+import parseConfig from './parse-config';
 
-export default function cli() {
+export default async function cli(configFile) {
+  const config = await parseConfig(configFile);
   return runner(
     process.stdout,
     process.stderr,
     process.cwd(),
     path.resolve(process.cwd(), 'node_bin'),
     path.resolve(process.cwd(), 'node_log'),
-    ['6.2.2'],
-    ['node --version', 'npm --version', 'more index.js >&2']
+    config.versions,
+    config.scripts,
   );
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,13 +3,23 @@ import runner from './index';
 import parseConfig from './parse-config';
 
 export default async function cli(configFile) {
+  const configDir = path.dirname(configFile);
   const config = await parseConfig(configFile);
+
+  const binDir = config.bin
+    ? path.resolve(configDir, config.bin)
+    : path.resolve(process.cwd(), 'node_bin');
+
+  const logDir = config.log
+    ? path.resolve(configDir, config.log)
+    : path.resolve(process.cwd(), 'node_log');
+
   return runner(
     process.stdout,
     process.stderr,
     process.cwd(),
-    path.resolve(process.cwd(), 'node_bin'),
-    path.resolve(process.cwd(), 'node_log'),
+    binDir,
+    logDir,
     config.versions,
     config.scripts,
   );

--- a/src/parse-config.js
+++ b/src/parse-config.js
@@ -12,5 +12,5 @@ function readFile(file) {
 export default async function parseConfig(configFile) {
   const content = await readFile(configFile);
   const config = yaml.safeLoad(content);
-  return config.runner;
+  return config.runner || {};
 }

--- a/src/parse-config.js
+++ b/src/parse-config.js
@@ -1,0 +1,16 @@
+import yaml from 'js-yaml';
+import fs from 'fs';
+
+function readFile(file) {
+  return new Promise((resolve, reject) =>
+    fs.readFile(file, 'utf-8', (error, data) =>
+      (error ? reject(error) : resolve(data))
+    )
+  );
+}
+
+export default async function parseConfig(configFile) {
+  const content = await readFile(configFile);
+  const config = yaml.safeLoad(content);
+  return config.runner;
+}

--- a/test/configs/appveyor.yml
+++ b/test/configs/appveyor.yml
@@ -1,0 +1,7 @@
+runner:
+  bin: ..\..\node_bin
+  log: ..\..\node_log
+  versions:
+    - 6.2.2
+  scripts:
+    - echo Default to appveyor.yml file

--- a/test/configs/fixture-1.yml
+++ b/test/configs/fixture-1.yml
@@ -1,0 +1,7 @@
+runner:
+  versions:
+    - 4.4.6
+    - 6.2.2
+  scripts:
+    - echo First
+    - echo Second

--- a/test/configs/fixture-2.yml
+++ b/test/configs/fixture-2.yml
@@ -1,0 +1,7 @@
+runner:
+  bin: ./fixture-2/bin
+  log: ./fixture-2/log
+  versions:
+    - 6.2.2
+  scripts:
+    - echo Check bin and log directories

--- a/test/configs/fixture-2/.gitignore
+++ b/test/configs/fixture-2/.gitignore
@@ -1,0 +1,3 @@
+# Fixture-2 test case generated files
+bin
+log

--- a/test/configs/fixture-3.yml
+++ b/test/configs/fixture-3.yml
@@ -1,0 +1,6 @@
+runner:
+  cwd: ./fixture-3
+  versions:
+    - 6.2.2
+  scripts:
+    - more file.txt

--- a/test/configs/fixture-3/file.txt
+++ b/test/configs/fixture-3/file.txt
@@ -1,0 +1,1 @@
+Here is fixture-3 test content.

--- a/test/tape.js
+++ b/test/tape.js
@@ -84,6 +84,12 @@ function hookStream(stream) {
   };
 }
 
+function hookCwd(targetPath) {
+  const originalCwd = process.cwd;
+  process.cwd = () => targetPath;
+  return () => (process.cwd = originalCwd);
+}
+
 export default function test(name, listener) {
   tape(name, async (t) => {
     // create unique log folder for each test case
@@ -104,6 +110,7 @@ export default function test(name, listener) {
       getStdout,
       getStderr,
       hookStream,
+      hookCwd,
     };
 
     // run the listener

--- a/test/tape.js
+++ b/test/tape.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import through2 from 'through2';
 import mkdirp from 'mkdirp-promise';
@@ -22,6 +23,32 @@ Test.prototype.below = function includes(a, b, msg, extra) {
     operator: 'below',
     expected: b,
     actual: a,
+    extra,
+  });
+};
+
+function doesPathExist(targetPath) {
+  try {
+    fs.accessSync(targetPath);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function findUpPath(targetPath) {
+  const pathDir = path.dirname(targetPath);
+  return doesPathExist(pathDir)
+    ? pathDir
+    : findUpPath(pathDir);
+}
+
+Test.prototype.exists = function exists(targetPath, msg, extra) {
+  this._assert(doesPathExist(targetPath), { // eslint-disable-line no-underscore-dangle
+    message: msg || 'should exist',
+    operator: 'exists',
+    expected: targetPath,
+    get actual() { return findUpPath(targetPath); },
     extra,
   });
 };

--- a/test/tape.js
+++ b/test/tape.js
@@ -40,6 +40,23 @@ function createStream() {
   };
 }
 
+function hookStream(stream) {
+  let str = '';
+  const originalStdoutWrite = stream._write; // eslint-disable-line no-underscore-dangle
+
+  // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+  stream._write = (chunk, encoding, done) => {
+    str += chunk;
+    done();
+  };
+
+  return () => {
+    // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+    stream._write = originalStdoutWrite;
+    return str;
+  };
+}
+
 export default function test(name, listener) {
   tape(name, async (t) => {
     // create unique log folder for each test case
@@ -59,6 +76,7 @@ export default function test(name, listener) {
       stderr,
       getStdout,
       getStderr,
+      hookStream,
     };
 
     // run the listener

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -2,6 +2,19 @@ import path from 'path';
 import test from './tape';
 import cli from '../src/cli';
 
+test('CLI should default config file to appveyor.yml', async (t, context) => {
+  const getStdout = context.hookStream(process.stdout);
+  const restoreCwd = context.hookCwd(path.resolve(__dirname, './configs'));
+
+  const code = await cli();
+  t.equal(code, 0);
+
+  const stdout = getStdout();
+  t.includes(stdout, 'Default to appveyor.yml file');
+
+  restoreCwd();
+});
+
 test('CLI should parse config and run scripts', async (t, context) => {
   const getStdout = context.hookStream(process.stdout);
 

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -16,3 +16,22 @@ test('CLI should parse config and run scripts', async (t, context) => {
   t.includes(stdout, 'First');
   t.includes(stdout, 'Second');
 });
+
+test('CLI should parse bin and log dir from config', async (t, context) => {
+  const getStdout = context.hookStream(process.stdout);
+
+  const configFile = path.resolve(__dirname, './configs/fixture-2.yml');
+  const code = await cli(configFile);
+
+  t.equal(code, 0);
+
+  const stdout = getStdout();
+  t.includes(stdout, 'Check bin and log directories');
+
+  const arch = process.arch === 'ia32' ? 'x86' : 'x64';
+  const binPath = path.resolve(__dirname, `./configs/fixture-2/bin/v6.2.2-${arch}/node.exe`);
+  t.exists(binPath);
+
+  const logPath = path.resolve(__dirname, './configs/fixture-2/log/v6.2.2-output.txt');
+  t.exists(logPath);
+});

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -35,3 +35,15 @@ test('CLI should parse bin and log dir from config', async (t, context) => {
   const logPath = path.resolve(__dirname, './configs/fixture-2/log/v6.2.2-output.txt');
   t.exists(logPath);
 });
+
+test('CLI should parse cwd from config', async (t, context) => {
+  const getStdout = context.hookStream(process.stdout);
+
+  const configFile = path.resolve(__dirname, './configs/fixture-3.yml');
+  const code = await cli(configFile);
+
+  t.equal(code, 0);
+
+  const stdout = getStdout();
+  t.includes(stdout, 'Here is fixture-3 test content.');
+});

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -1,0 +1,18 @@
+import path from 'path';
+import test from './tape';
+import cli from '../src/cli';
+
+test('CLI should parse config and run scripts', async (t, context) => {
+  const getStdout = context.hookStream(process.stdout);
+
+  const configFile = path.resolve(__dirname, './configs/fixture-1.yml');
+  const code = await cli(configFile);
+
+  t.equal(code, 0);
+
+  const stdout = getStdout();
+  t.includes(stdout, '4.4.6');
+  t.includes(stdout, '6.2.2');
+  t.includes(stdout, 'First');
+  t.includes(stdout, 'Second');
+});


### PR DESCRIPTION
The following configs are parsed from YAML config file:
- CWD
- bin and log dir
- Target versions
- Scripts

If the YAML config file is missing, default to `appveyor.yml` under `process.cwd()`.

The _stdout_ and _stderr_ output streams are not overridden now.
