### PR TITLE
Tweak YAML config schema

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,7 @@ export default async function cli(configFile = 'appveyor.yml') {
     cwd,
     binDir,
     logDir,
-    config.versions || [],
-    config.scripts || [],
+    config.version || [],
+    config.script || [],
   );
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,7 @@ import path from 'path';
 import runner from './index';
 import parseConfig from './parse-config';
 
-export default async function cli(configFile = 'appveyor.yml') {
+export default async function cli(configFile = 'appveyor-runner.yml') {
   const configDir = path.dirname(path.resolve(process.cwd(), configFile));
   const config = await parseConfig(configFile);
 

--- a/src/parse-config.js
+++ b/src/parse-config.js
@@ -12,5 +12,5 @@ function readFile(file) {
 export default async function parseConfig(configFile) {
   const content = await readFile(configFile);
   const config = yaml.safeLoad(content);
-  return config.runner || {};
+  return config || {};
 }

--- a/test/configs/appveyor-runner.yml
+++ b/test/configs/appveyor-runner.yml
@@ -1,0 +1,8 @@
+bin: ..\..\node_bin
+log: ..\..\node_log
+
+version:
+  - 6.2.2
+
+script:
+  - echo Default to appveyor-runner.yml file

--- a/test/configs/appveyor.yml
+++ b/test/configs/appveyor.yml
@@ -1,7 +1,0 @@
-runner:
-  bin: ..\..\node_bin
-  log: ..\..\node_log
-  versions:
-    - 6.2.2
-  scripts:
-    - echo Default to appveyor.yml file

--- a/test/configs/fixture-1.yml
+++ b/test/configs/fixture-1.yml
@@ -1,7 +1,7 @@
-runner:
-  versions:
-    - 4.4.6
-    - 6.2.2
-  scripts:
-    - echo First
-    - echo Second
+version:
+  - 4.4.6
+  - 6.2.2
+
+script:
+  - echo First
+  - echo Second

--- a/test/configs/fixture-2.yml
+++ b/test/configs/fixture-2.yml
@@ -1,7 +1,8 @@
-runner:
-  bin: ./fixture-2/bin
-  log: ./fixture-2/log
-  versions:
-    - 6.2.2
-  scripts:
-    - echo Check bin and log directories
+bin: ./fixture-2/bin
+log: ./fixture-2/log
+
+version:
+  - 6.2.2
+
+script:
+  - echo Check bin and log directories

--- a/test/configs/fixture-3.yml
+++ b/test/configs/fixture-3.yml
@@ -1,6 +1,7 @@
-runner:
-  cwd: ./fixture-3
-  versions:
-    - 6.2.2
-  scripts:
-    - more file.txt
+cwd: ./fixture-3
+
+version:
+  - 6.2.2
+
+script:
+  - more file.txt

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -2,8 +2,7 @@ import path from 'path';
 import test from './tape';
 import cli from '../src/cli';
 
-/* TODO pending to change default config file.
-test('CLI should default config file to appveyor.yml', async (t, context) => {
+test('CLI should default config file to appveyor-runner.yml', async (t, context) => {
   const getStdout = context.hookStream(process.stdout);
   const restoreCwd = context.hookCwd(path.resolve(__dirname, './configs'));
 
@@ -11,11 +10,10 @@ test('CLI should default config file to appveyor.yml', async (t, context) => {
   t.equal(code, 0);
 
   const stdout = getStdout();
-  t.includes(stdout, 'Default to appveyor.yml file');
+  t.includes(stdout, 'Default to appveyor-runner.yml file');
 
   restoreCwd();
 });
-*/
 
 test('CLI should parse config and run scripts', async (t, context) => {
   const getStdout = context.hookStream(process.stdout);

--- a/test/yaml.js
+++ b/test/yaml.js
@@ -2,6 +2,7 @@ import path from 'path';
 import test from './tape';
 import cli from '../src/cli';
 
+/* TODO pending to change default config file.
 test('CLI should default config file to appveyor.yml', async (t, context) => {
   const getStdout = context.hookStream(process.stdout);
   const restoreCwd = context.hookCwd(path.resolve(__dirname, './configs'));
@@ -14,6 +15,7 @@ test('CLI should default config file to appveyor.yml', async (t, context) => {
 
   restoreCwd();
 });
+*/
 
 test('CLI should parse config and run scripts', async (t, context) => {
   const getStdout = context.hookStream(process.stdout);


### PR DESCRIPTION
Change config file schema. Put block at the root level.
- Rename: versions -> version
- Rename: scripts -> script

Default config file to `appveyor-runner.yml`.
- The `appveyor.yml` does not allow customized blocks.
- It is needed to use new file to define runner configs.
